### PR TITLE
fix: allow ghost click directive to be used outside carousel

### DIFF
--- a/projects/ng-carousel/src/lib/prevent-ghost-click.directive.ts
+++ b/projects/ng-carousel/src/lib/prevent-ghost-click.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, OnDestroy, OnInit } from '@angular/core';
+import { Directive, ElementRef, OnDestroy, OnInit, Optional } from '@angular/core';
 
 import { PanRecognizerService } from './private/service/pan-recognizer.service';
 
@@ -13,7 +13,7 @@ export class PreventGhostClickDirective implements OnInit, OnDestroy {
 
     constructor(
         private elementRef: ElementRef<HTMLElement>,
-        private panRecognizer: PanRecognizerService<any>,
+        @Optional() private panRecognizer: PanRecognizerService<any>,
     ) {
     }
 
@@ -26,7 +26,7 @@ export class PreventGhostClickDirective implements OnInit, OnDestroy {
     }
 
     private preventEvent(event: MouseEvent | TouchEvent): void {
-        if (this.panRecognizer.isPanning) {
+        if (this.panRecognizer?.isPanning) {
             event.preventDefault();
             event.stopImmediatePropagation();
         }

--- a/projects/ng-carousel/src/lib/private/service/pan-recognizer.service.ts
+++ b/projects/ng-carousel/src/lib/private/service/pan-recognizer.service.ts
@@ -16,7 +16,7 @@ export class PanRecognizerService<T> {
 
     /**
      * Tells for the whole chain (pointer events -> click events),
-     * that pan is still ongoing (event after pointer is up),
+     * that pan is still ongoing (even after pointer is up),
      * so we can prevent ghost clicks
      */
     isPanning = false;


### PR DESCRIPTION
It would be NOOP but in case a component reused both inside and outside carousel - it won't error